### PR TITLE
Fix humidifier crash, add WebSocket push, add diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Lint
+```bash
+scripts/lint        # runs ruff format + ruff check --fix
+```
+
+### Dev environment
+```bash
+scripts/setup       # pip install -r requirements.txt (installs ruff)
+scripts/develop     # launches a local Home Assistant instance with the integration loaded
+```
+The `scripts/develop` script sets `PYTHONPATH` to include `custom_components/` and runs `hass --config ./config --debug`. The `config/configuration.yaml` in this repo is pre-configured for local development.
+
+There is no automated test suite. Manual testing is done by running the integration inside Home Assistant and observing logs/behavior.
+
+## Architecture
+
+### Integration entry point (`__init__.py`)
+On `async_setup_entry`, the integration:
+1. Logs in via `DreoClient` (from the `pydreo-cloud` library) using stored credentials.
+2. Calls `client.get_devices()` which returns a list of device dicts, each containing device metadata **and** a `"config"` key holding per-model capability configuration.
+3. Creates one `DreoDataUpdateCoordinator` per device, seeds it with the initial state from the device list, then forwards setup to all platform modules.
+
+### Config-driven entity creation
+Device capability is entirely server-driven: each device dict contains a `"config"` section (accessed via `DreoEntityConfigSpec.TOP_CONFIG`) that declares what Home Assistant entities and features the device supports. Platform modules check `entitySupports` (a list of `Platform` values inside the config) before creating any entity. This avoids hardcoding per-model logic in the integration.
+
+### Coordinator & data classes (`coordinator.py`)
+`DreoDataUpdateCoordinator` wraps HA's `DataUpdateCoordinator` with a 15-second poll interval. It selects a `data_processor` static method based on `device_type` (a `DreoDeviceType` string enum). Each typed `DeviceData` class (e.g. `DreoFanDeviceData`, `DreoHacDeviceData`) holds parsed state fields and exposes a `process_*` static method that translates the raw API `state` dict into typed attributes using `DreoDirective` string enum keys.
+
+### Base entity (`entity.py`)
+`DreoEntity` extends `CoordinatorEntity`. All platform entities inherit from it. `async_send_command_and_update` is the canonical way to send a directive to the device: it calls `client.update_status(device_id, **kwargs)`, then triggers a coordinator refresh. Error translation keys come from `DreoErrorCode`.
+
+### Platform modules
+Each HA platform (`fan.py`, `climate.py`, `humidifier.py`, `light.py`, `number.py`, `select.py`, `sensor.py`, `switch.py`) has an `async_setup_entry` that iterates `config_entry.runtime_data.devices`, checks device type and `entitySupports`, looks up the coordinator by `deviceSn`, and instantiates typed entity subclasses.
+
+### Status dependency (`status_dependency.py`)
+`DreotStatusDependency` is a callable that evaluates whether a select/number entity should be available based on the current device state. It reads `status_available_dependencies` from the model config — a list of `{directive_name, dependency_values, condition}` rules evaluated with AND/OR logic against the current `DeviceData` object.
+
+### Key enums in `const.py`
+- `DreoDeviceType` — device type strings from the API (`"fan"`, `"circulation_fan"`, `"hac"`, etc.)
+- `DreoDirective` — API state field names (`"power_switch"`, `"mode"`, `"speed"`, etc.)
+- `DreoEntityConfigSpec` — keys inside the per-model config dict
+- `DreoFeatureSpec` — keys inside config sub-sections (e.g. `"speed_range"`, `"preset_modes"`)
+- `DreoErrorCode` — translation keys for HA error messages (defined in `translations/en.json`)
+
+### Adding support for a new device type
+1. Add a new value to `DreoDeviceType` in `const.py`.
+2. Create a `Dreo<Type>DeviceData` class in `coordinator.py` with a `process_<type>_data` static method.
+3. Register the processor in `DreoDataUpdateCoordinator.__init__` under the new device type.
+4. Add entity classes to the relevant platform files and gate them behind the correct `device_type` check or `entitySupports` flag.

--- a/custom_components/dreo/climate.py
+++ b/custom_components/dreo/climate.py
@@ -105,7 +105,6 @@ class DreoHacClimate(DreoEntity, ClimateEntity):
         coordinator: DreoDataUpdateCoordinator,
     ) -> None:
         """Initialize the Dreo HAC climate entity."""
-
         super().__init__(device, coordinator, "climate", None)
 
         fan_config = coordinator.model_config.get(
@@ -151,13 +150,11 @@ class DreoHacClimate(DreoEntity, ClimateEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-
         self._update_attributes()
         super()._handle_coordinator_update()
 
     def _update_attributes(self) -> None:
         """Update attributes from coordinator data."""
-
         if not self.coordinator.data:
             return
 
@@ -209,7 +206,6 @@ class DreoHacClimate(DreoEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-
         if hvac_mode == HVACMode.OFF:
             await self.async_send_command_and_update(
                 DreoErrorCode.TURN_OFF_FAILED, power_switch=False
@@ -229,7 +225,6 @@ class DreoHacClimate(DreoEntity, ClimateEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
-
         if self._attr_preset_modes and preset_mode not in self._attr_preset_modes:
             _LOGGER.error("Invalid preset mode: %s", preset_mode)
             return
@@ -307,7 +302,6 @@ class DreoHacClimate(DreoEntity, ClimateEntity):
 
     async def async_set_humidity(self, humidity: int) -> None:
         """Set new target humidity."""
-
         if self._attr_hvac_mode != HVACMode.DRY:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/custom_components/dreo/config_flow.py
+++ b/custom_components/dreo/config_flow.py
@@ -3,12 +3,11 @@
 import hashlib
 from typing import Any
 
-from pydreo.client import DreoClient
-from pydreo.exceptions import DreoBusinessException, DreoException
 import voluptuous as vol
-
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from pydreo.client import DreoClient
+from pydreo.exceptions import DreoBusinessException, DreoException
 
 from .const import DOMAIN
 
@@ -45,7 +44,6 @@ class DreoFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-
         errors: dict[str, str] = {}
         if user_input:
             username = user_input[CONF_USERNAME]

--- a/custom_components/dreo/diagnostics.py
+++ b/custom_components/dreo/diagnostics.py
@@ -1,0 +1,39 @@
+"""Diagnostics support for Dreo."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from . import DreoConfigEntry
+
+TO_REDACT_CONFIG = {CONF_USERNAME, CONF_PASSWORD}
+TO_REDACT_DEVICE = {"deviceSn", "wifi_ssid", "wifi_bssid"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: Any,
+    entry: DreoConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    data = entry.runtime_data
+
+    device_diags = []
+    for device in data.devices:
+        redacted = async_redact_data(device, TO_REDACT_DEVICE)
+        device_sn = device.get("deviceSn", "")
+        coordinator = data.coordinators.get(device_sn)
+        redacted["coordinator_has_data"] = (
+            coordinator is not None and coordinator.data is not None
+        )
+        device_diags.append(redacted)
+
+    return {
+        "config_entry_data": async_redact_data(dict(entry.data), TO_REDACT_CONFIG),
+        "websocket_connected": (
+            data.websocket.connected if data.websocket is not None else False
+        ),
+        "devices": device_diags,
+    }

--- a/custom_components/dreo/entity.py
+++ b/custom_components/dreo/entity.py
@@ -3,16 +3,15 @@
 from functools import partial
 from typing import Any
 
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pydreo.exceptions import (
     DreoAccessDeniedException,
     DreoBusinessException,
     DreoException,
     DreoFlowControlException,
 )
-
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import DreoDataUpdateCoordinator
@@ -31,7 +30,6 @@ class DreoEntity(CoordinatorEntity[DreoDataUpdateCoordinator]):
         name: str | None = None,
     ) -> None:
         """Initialize the Dreo entity."""
-
         super().__init__(coordinator)
         self._device_id = device.get("deviceSn")
         self._model = device.get("model")
@@ -55,7 +53,6 @@ class DreoEntity(CoordinatorEntity[DreoDataUpdateCoordinator]):
         self, error_translation_key: str, **kwargs: Any
     ) -> None:
         """Call a device command handling error messages and update entity state."""
-
         try:
             await self.coordinator.hass.async_add_executor_job(
                 partial(
@@ -75,7 +72,8 @@ class DreoEntity(CoordinatorEntity[DreoDataUpdateCoordinator]):
             ) from ex
 
     def _set_attrs(self, target: Any, attrs: dict[str, Any]) -> None:
-        """Safely set multiple attributes on a target object.
+        """
+        Safely set multiple attributes on a target object.
 
         Only sets attributes that exist on the target to avoid AttributeError.
         """
@@ -86,7 +84,8 @@ class DreoEntity(CoordinatorEntity[DreoDataUpdateCoordinator]):
     def _set_attrs_if(
         self, condition: bool, target: Any, attrs: dict[str, Any]
     ) -> None:
-        """Set attributes on target if condition is true.
+        """
+        Set attributes on target if condition is true.
 
         This is a convenience wrapper around _set_attrs.
         """

--- a/custom_components/dreo/fan.py
+++ b/custom_components/dreo/fan.py
@@ -164,7 +164,6 @@ class DreoFan(DreoEntity, FanEntity):
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of fan."""
-
         if percentage <= 0:
             await self.async_turn_off()
             return
@@ -187,7 +186,6 @@ class DreoFan(DreoEntity, FanEntity):
         oscillate: bool | None = None,
     ) -> None:
         """Execute fan command with common parameter handling."""
-
         command_params: dict[str, Any] = {}
 
         if not self._attr_is_on:

--- a/custom_components/dreo/humidifier.py
+++ b/custom_components/dreo/humidifier.py
@@ -102,7 +102,6 @@ async def async_setup_entry(
 class DreoHecHumidifier(DreoEntity, HumidifierEntity):
     """Dreo HEC (Hybrid Evaporative Cooler) humidifier entity."""
 
-    _attr_supported_features = HumidifierEntityFeature.MODES
     _attr_is_on = False
     _attr_mode: str | None = None
     _attr_current_humidity: int | None = None
@@ -130,6 +129,13 @@ class DreoHecHumidifier(DreoEntity, HumidifierEntity):
         self._attr_available_modes = (
             humidifier_config.get(DreoFeatureSpec.PRESET_MODES) or []
         )
+
+    @property
+    def supported_features(self) -> HumidifierEntityFeature:
+        """Return supported features based on device config."""
+        if self._attr_available_modes:
+            return HumidifierEntityFeature.MODES
+        return HumidifierEntityFeature(0)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -238,7 +244,6 @@ class DreoHecHumidifier(DreoEntity, HumidifierEntity):
 class DreoHumidifier(DreoEntity, HumidifierEntity):
     """Dreo Humidifier entity for dedicated humidifier devices like HHM001S."""
 
-    _attr_supported_features = HumidifierEntityFeature.MODES
     _attr_is_on = False
     _attr_mode: str | None = None
     _attr_current_humidity: int | None = None
@@ -294,6 +299,13 @@ class DreoHumidifier(DreoEntity, HumidifierEntity):
             ]
         else:
             self._attr_fog_level_range = [1, 6]
+
+    @property
+    def supported_features(self) -> HumidifierEntityFeature:
+        """Return supported features based on device config."""
+        if self._attr_available_modes:
+            return HumidifierEntityFeature.MODES
+        return HumidifierEntityFeature(0)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -442,7 +454,6 @@ class DreoHumidifier(DreoEntity, HumidifierEntity):
 class DreoDehumidifier(DreoEntity, HumidifierEntity):
     """Expose target humidity adjustment for HDH devices in Auto/Custom."""
 
-    _attr_supported_features = HumidifierEntityFeature.MODES
     _attr_is_on = False
     _attr_mode: str | None = None
     _attr_current_humidity: int | None = None
@@ -482,6 +493,13 @@ class DreoDehumidifier(DreoEntity, HumidifierEntity):
         self._attr_description_limits = humidifier_config.get(
             DreoFeatureSpec.DESCRIPTION_LIMITS, {}
         )
+
+    @property
+    def supported_features(self) -> HumidifierEntityFeature:
+        """Return supported features based on device config."""
+        if self._attr_available_modes:
+            return HumidifierEntityFeature.MODES
+        return HumidifierEntityFeature(0)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -129,7 +129,6 @@ class DreoRGBLight(DreoEntity, LightEntity):
         coordinator: DreoDataUpdateCoordinator,
     ) -> None:
         """Initialize the Dreo circulation fan RGB light."""
-
         super().__init__(device, coordinator, "light", "RGB Light")
 
         device_id = device.get("deviceSn")
@@ -294,7 +293,6 @@ class DreoRGBLight(DreoEntity, LightEntity):
 
     async def async_set_light_speed(self, speed: int) -> None:
         """Set the light animation speed (for Circle and Breath modes)."""
-
         rgb_mode = None
         if self.coordinator.data and _has_rgb_features(self.coordinator.data):
             rgb_mode = getattr(self.coordinator.data, "rgb_mode", None)

--- a/custom_components/dreo/manifest.json
+++ b/custom_components/dreo/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": ["logger"],
   "documentation": "https://github.com/dreo-team/hass-dreoverse/blob/master/README.md",
   "integration_type": "hub",
-  "iot_class": "cloud_polling",
+  "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dreo-team/hass-dreoverse/issues",
   "quality_scale": "bronze",
   "requirements": ["pydreo-cloud==1.0.0"],

--- a/custom_components/dreo/select.py
+++ b/custom_components/dreo/select.py
@@ -200,7 +200,6 @@ class DreoGenericModeSelect(DreoEntity, SelectEntity):
         select_mappings: dict[str, Any],
     ) -> None:
         """Initialize the Generic Mode Select."""
-
         super().__init__(
             device, coordinator, "select", select_mappings.get("attr_name")
         )

--- a/custom_components/dreo/sensor.py
+++ b/custom_components/dreo/sensor.py
@@ -120,7 +120,8 @@ class DreoGenericSensor(DreoEntity, SensorEntity):
             self._attr_suggested_unit_of_measurement = None
 
     def get_initial_entity_options(self):
-        """Return initial entity options.
+        """
+        Return initial entity options.
 
         For temperature sensors, return None to prevent storing suggested_unit_of_measurement,
         allowing Home Assistant's automatic temperature conversion to work.
@@ -131,7 +132,8 @@ class DreoGenericSensor(DreoEntity, SensorEntity):
 
     @callback
     def _async_read_entity_options(self) -> None:
-        """Read entity options from entity registry.
+        """
+        Read entity options from entity registry.
 
         For temperature sensors, clear _sensor_option_unit_of_measurement to allow
         Home Assistant's automatic temperature conversion to work.

--- a/custom_components/dreo/status_dependency.py
+++ b/custom_components/dreo/status_dependency.py
@@ -12,7 +12,6 @@ class DreotStatusDependency:
 
     def __init__(self, status_available_dependencies: list[dict[str, Any]]) -> None:
         """Initialize with dependency definitions."""
-
         self._status_available_dependencies = status_available_dependencies
 
     def __call__(self, data: DreoGenericDeviceData) -> bool:
@@ -20,7 +19,8 @@ class DreotStatusDependency:
         return self.matches(data)
 
     def matches(self, data: DreoGenericDeviceData) -> bool:
-        """Return True if current state matches configured dependency states.
+        """
+        Return True if current state matches configured dependency states.
 
         Each dependency item may include:
         - directive_name: name of the field on data
@@ -29,7 +29,6 @@ class DreotStatusDependency:
 
         If no valid dependency is defined, default to True (no restriction).
         """
-
         if not self._status_available_dependencies:
             return True
 

--- a/custom_components/dreo/switch.py
+++ b/custom_components/dreo/switch.py
@@ -112,7 +112,6 @@ class DreoToggleSwitch(DreoEntity, SwitchEntity):
         data: DreoToggleSwitchData,
     ) -> None:
         """Initialize the toggle switch entity for a given HAP device field."""
-
         super().__init__(device, coordinator, "switch", data.name)
         self._field = data.field
         self._error_key = data.error_key
@@ -121,7 +120,6 @@ class DreoToggleSwitch(DreoEntity, SwitchEntity):
 
     def _is_ui_available(self) -> bool:
         """Return if UI should allow interaction for this switch."""
-
         base_available = super().available
         data = getattr(self.coordinator, "data", None)
         if not data:
@@ -143,14 +141,12 @@ class DreoToggleSwitch(DreoEntity, SwitchEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updates from the coordinator to refresh on/off state."""
-
         state = bool(getattr(self.coordinator.data, self._field, True))
         self._attr_is_on = bool(state) if state is not None else False
         super()._handle_coordinator_update()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-
         if not self._is_ui_available():
             _LOGGER.debug(
                 "Ignoring turn_on for %s because device is unavailable or power policy blocks it",

--- a/custom_components/dreo/websocket.py
+++ b/custom_components/dreo/websocket.py
@@ -1,0 +1,137 @@
+"""WebSocket client for Dreo real-time state updates."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+WEBSOCKET_URL = "wss://wsb-{region}.dreo-tech.com/websocket"
+PING_INTERVAL = 15
+PING_MESSAGE = "2"
+RECONNECT_DELAY = 5
+
+# Map token region suffix to WebSocket region slug
+REGION_MAP: dict[str, str] = {
+    "NA": "us",
+    "US": "us",
+    "EU": "eu",
+}
+
+
+class DreoWebSocket:
+    """Manage a WebSocket connection for real-time Dreo device updates."""
+
+    def __init__(
+        self,
+        token: str,
+        region: str,
+        on_message: Callable[[str, dict[str, Any]], None],
+    ) -> None:
+        """Initialize the WebSocket client."""
+        self._token = token
+        self._region = REGION_MAP.get(region.upper(), "us")
+        self._on_message = on_message
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._session: aiohttp.ClientSession | None = None
+        self._running = False
+        self._task: asyncio.Task[None] | None = None
+
+    @property
+    def connected(self) -> bool:
+        """Return True if WebSocket is open."""
+        return self._ws is not None and not self._ws.closed
+
+    async def start(self) -> None:
+        """Start the WebSocket connection loop."""
+        self._running = True
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Gracefully close the WebSocket and clean up."""
+        self._running = False
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        if self._session and not self._session.closed:
+            await self._session.close()
+        if self._task:
+            self._task.cancel()
+
+    async def _run(self) -> None:
+        """Reconnect loop — keeps retrying until stopped."""
+        while self._running:
+            try:
+                await self._connect_and_listen()
+            except Exception:
+                _LOGGER.debug(
+                    "Dreo WebSocket disconnected, reconnecting in %ss",
+                    RECONNECT_DELAY,
+                    exc_info=True,
+                )
+            if self._running:
+                await asyncio.sleep(RECONNECT_DELAY)
+
+    async def _connect_and_listen(self) -> None:
+        """Open a WebSocket and consume messages until closed."""
+        timestamp = int(time.time() * 1000)
+        url = (
+            f"{WEBSOCKET_URL.format(region=self._region)}"
+            f"?accessToken={self._token}&timestamp={timestamp}"
+        )
+
+        self._session = aiohttp.ClientSession()
+        try:
+            self._ws = await self._session.ws_connect(url)
+            _LOGGER.info("Dreo WebSocket connected to %s region", self._region)
+
+            ping_task = asyncio.create_task(self._ping_loop())
+            try:
+                async for msg in self._ws:
+                    if msg.type == aiohttp.WSMsgType.TEXT:
+                        self._process_message(msg.data)
+                    elif msg.type in (
+                        aiohttp.WSMsgType.CLOSED,
+                        aiohttp.WSMsgType.ERROR,
+                    ):
+                        break
+            finally:
+                ping_task.cancel()
+        finally:
+            if self._session and not self._session.closed:
+                await self._session.close()
+            self._ws = None
+            self._session = None
+
+    async def _ping_loop(self) -> None:
+        """Send periodic text pings to keep the connection alive."""
+        try:
+            while self._ws and not self._ws.closed:
+                await self._ws.send_str(PING_MESSAGE)
+                await asyncio.sleep(PING_INTERVAL)
+        except (ConnectionError, asyncio.CancelledError):
+            pass
+
+    def _process_message(self, raw: str) -> None:
+        """Parse an incoming WebSocket message and dispatch to callback."""
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return
+
+        device_sn: str | None = data.get("devicesn")
+        reported: dict[str, Any] | None = data.get("reported")
+
+        if device_sn and isinstance(reported, dict) and reported:
+            _LOGGER.debug(
+                "WebSocket push for %s: %s",
+                device_sn,
+                reported,
+            )
+            self._on_message(device_sn, reported)


### PR DESCRIPTION
- Fix supported_features on all humidifier entities to dynamically check for available modes instead of always advertising MODES support. Prevents NoneType crash on models like DR-HHM014S that expose no preset modes, and returns proper HumidifierEntityFeature enum instead of plain int (HA 2025+ compatibility).

- Add WebSocket client (websocket.py) for real-time state updates via wss://wsb-{region}.dreo-tech.com. Merges partial push updates into last known state and reprocesses through existing data pipeline. Falls back gracefully to 15s REST polling if WebSocket fails. Changed iot_class from cloud_polling to cloud_push in manifest.

- Add diagnostics.py to fix blocking import_module warning during setup. Reports config entry, device info, and WebSocket status with sensitive fields redacted.

- Ruff format applied across all files.